### PR TITLE
Support for using channel names as IDs in PL2 files

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/plexon2.py
+++ b/src/spikeinterface/extractors/neoextractors/plexon2.py
@@ -123,9 +123,9 @@ class Plexon2EventExtractor(NeoBaseEventExtractor):
 
     NeoRawIOClass = "Plexon2RawIO"
 
-    def __init__(self, folder_path, block_index=None):
+    def __init__(self, folder_path, block_index=None, use_names_as_ids=True):
         neo_kwargs = self.map_to_neo_kwargs(folder_path)
-        NeoBaseEventExtractor.__init__(self, block_index=block_index, **neo_kwargs)
+        NeoBaseEventExtractor.__init__(self, block_index=block_index, use_names_as_ids=use_names_as_ids, **neo_kwargs)
 
     @classmethod
     def map_to_neo_kwargs(cls, folder_path):


### PR DESCRIPTION
Hi!  I was having issues using on the event ids read from .pl2 files. The ids were all numbers and not unique (like '1', '2', ..., '1', '2', ..., which are supposed to be 'KBD01', 'KBD02', ... 'EVT01', 'EVT02'...). So I added a feature to use event names as ids for .pl2 files.

## Summary by copilot

This pull request introduces a new feature to allow the use of channel names as unique identifiers (`use_names_as_ids`) in the Neo-based event extractors. It modifies the constructors and logic in several classes to support this functionality while maintaining backward compatibility.

### Enhancements to Neo-based event extractors:

* `NeoBaseEventExtractor`:
  - Added a `use_names_as_ids` parameter to the constructor. When enabled, channel names are used as identifiers instead of channel IDs, with a validation check to ensure names are unique.
  - Updated the initialization logic to pass the `use_names_as_ids` flag to `NeoEventSegment`.

* `NeoEventSegment`:
  - Modified the constructor to accept the `use_names_as_ids` parameter and store it as an instance attribute.
  - Updated the `get_events` method to use either channel names or IDs based on the `use_names_as_ids` flag.

* `Plexon2EventExtractor`:
  - Updated the constructor to include the `use_names_as_ids` parameter, defaulting to `True` for this extractor. This ensures that channel names are used as identifiers by default for Plexon2 files.